### PR TITLE
Quit on WindowEvent::CloseRequested

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -183,6 +183,7 @@ impl Gpu {
                 width: width as f64,
                 height: height as f64,
             })
+            .with_resizable(false)
             .with_title("Hello world");
         let cb = glium::glutin::ContextBuilder::new()
             .with_srgb(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,14 +210,15 @@ where
         let (gpu, _) = Gpu::new()?;
         let buffer = gpu.build_texture(output_width, output_height)?;
 
+        std::fs::create_dir_all(&base_path)
+            .expect(&format!("To create save directory {}", base_path.display()));
+
         (
             gpu,
             RenderStrategy::File {
                 buffer,
                 output_path: move |frame_number: usize, seed: u64| {
                     let mut base_path = base_path.clone();
-                    std::fs::create_dir_all(&base_path)
-                        .expect(&format!("To create save directory {:?}", base_path));
                     base_path.push(format!(
                         "{}_{number:>0width$}.png",
                         seed,

--- a/src/render.rs
+++ b/src/render.rs
@@ -197,7 +197,14 @@ impl<'a, F1: Fn() -> Frame + 'a, F2: Fn(usize, u64) -> PathBuf> Renderer<'a, F1,
                 let mut new_seed = None;
                 let mut should_quit = false;
                 events_loop.poll_events(|event| {
-                    use glutin::{DeviceEvent, ElementState, Event, KeyboardInput, VirtualKeyCode};
+                    use glutin::{
+                        DeviceEvent,
+                        ElementState,
+                        Event,
+                        KeyboardInput,
+                        VirtualKeyCode,
+                        WindowEvent,
+                    };
                     match event {
                         Event::DeviceEvent {
                             event:
@@ -219,6 +226,12 @@ impl<'a, F1: Fn() -> Frame + 'a, F2: Fn(usize, u64) -> PathBuf> Renderer<'a, F1,
                             ..
                         } => {
                             new_seed = Some(random());
+                        }
+                        Event::WindowEvent {
+                            event: WindowEvent::CloseRequested,
+                            ..
+                        } => {
+                            should_quit = true;
                         }
                         _ => {}
                     }


### PR DESCRIPTION
If we receive a `WindowEvent::CloseRequested` event, we quit.

Also the window is created to be non-resizable. The program doesn't really behave well when it's resized and my window manager kept resizing it because it was resizable.

Also the output path is created on init instead of for each frame in the file render strategy. This isn't _that_ important so you can ignore it or ask me to remove it. It was the only part that seemed mildly worthwhile out of some larger changes that didn't work out.