### PR TITLE
Implement `cargo clippy` suggestions

### DIFF
--- a/src/forms/polygon.rs
+++ b/src/forms/polygon.rs
@@ -15,17 +15,17 @@ pub struct Polygon {
 
 impl Polygon {
     /// Returns an iterator over the polygon's vertices.
-    pub fn vertices<'a>(&'a self) -> impl DoubleEndedIterator<Item = P2> + Clone + 'a {
+    pub fn vertices(&self) -> impl DoubleEndedIterator<Item = P2> + Clone + '_ {
         self.vertices.iter().copied()
     }
 
     /// Returns an iterator over unique references to the polgyon's vertices.
-    pub fn vertices_mut<'a>(&'a mut self) -> impl DoubleEndedIterator<Item = &'a mut P2> + 'a {
+    pub fn vertices_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut P2> + '_ {
         self.vertices.iter_mut()
     }
 
     /// Returns an iterator over each vertex in the form (left neighbor, vertex, right neighbor).
-    pub fn vertices_with_neighbors<'a>(&'a self) -> impl Iterator<Item = (P2, P2, P2)> + 'a {
+    pub fn vertices_with_neighbors(&self) -> impl Iterator<Item = (P2, P2, P2)> + '_ {
         let last_iter = self.vertices().rev().take(1);
         last_iter
             .clone()

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -63,7 +63,7 @@ impl Uniforms for UniformBuffer {
     fn visit_values<'a, F: FnMut(&str, UniformValue<'a>)>(&'a self, mut f: F) {
         if let Some(user_uniforms) = self.user_uniforms.as_ref().map(Rc::as_ref) {
             user_uniforms.visit_owned_values(&mut |name, v| {
-                let uniform_value = v.into_uniform_value();
+                let uniform_value = v.as_uniform_value();
                 let uniform_value: UniformValue<'a> = unsafe { std::mem::transmute(uniform_value) };
                 f(name, uniform_value)
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ where
         let buffer = gpu.build_texture(output_width, output_height)?;
 
         std::fs::create_dir_all(&base_path)
-            .expect(&format!("To create save directory {}", base_path.display()));
+            .unwrap_or_else(|_| panic!("To create save directory {}", base_path.display()));
 
         (
             gpu,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,8 +279,8 @@ where
                 ..options.clone()
             },
             rng: &mut rng,
-            output_width: output_width,
-            output_height: output_height,
+            output_width,
+            output_height,
         };
 
         let report = renderer.render_frames(|ctx, canvas| paint_fn(ctx, canvas))?;

--- a/src/render.rs
+++ b/src/render.rs
@@ -252,7 +252,7 @@ impl<'a, F1: Fn() -> Frame + 'a, F2: Fn(usize, u64) -> PathBuf> Renderer<'a, F1,
                 )?;
 
                 if frame_number > self.options.delay {
-                    let raw: glium::texture::RawImage2d<u8> = self.gpu.read_to_ram(&buffer)?;
+                    let raw: glium::texture::RawImage2d<u8> = self.gpu.read_to_ram(buffer)?;
                     let image: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_raw(
                         self.output_width,
                         self.output_height,

--- a/src/render.rs
+++ b/src/render.rs
@@ -180,7 +180,7 @@ impl<'a, F1: Fn() -> Frame + 'a, F2: Fn(usize, u64) -> PathBuf> Renderer<'a, F1,
                         },
                     },
                 );
-                let mut quad_canvas = Canvas::new(shader.clone(), self.options.world.scale);
+                let mut quad_canvas = Canvas::new(shader, self.options.world.scale);
                 quad_canvas.paint(Filled(self.options.world));
 
                 let mut frame = get_frame();

--- a/src/render.rs
+++ b/src/render.rs
@@ -259,7 +259,7 @@ impl<'a, F1: Fn() -> Frame + 'a, F2: Fn(usize, u64) -> PathBuf> Renderer<'a, F1,
                         raw.data
                             .into_par_iter()
                             .map(|v| v.convert::<f32>())
-                            .map(|v: f32| <Srgb as TransferFn>::from_linear(v))
+                            .map(<Srgb as TransferFn>::from_linear)
                             .map(|v| v.convert::<u8>())
                             .collect(),
                     )

--- a/src/render.rs
+++ b/src/render.rs
@@ -85,7 +85,7 @@ impl<'a, F1: Fn() -> Frame + 'a, F2: Fn(usize, u64) -> PathBuf> Renderer<'a, F1,
         let end_frame = self.options.world.frames.map(|f| f + self.options.delay);
         for frame in std::iter::successors(Some(0), move |last| {
             if let Some(end_frame) = end_frame {
-                if last + 1 <= end_frame {
+                if last < &end_frame {
                     Some(last + 1)
                 } else {
                     None

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -14,7 +14,7 @@ pub trait OwnedUniforms {
 
 /// A trait for types which can represent themselves as `glium::UniformValue`.
 pub trait IntoUniformValue {
-    fn as_uniform_value<'a>(&'a self) -> UniformValue<'a>;
+    fn as_uniform_value(& self) -> UniformValue;
 }
 
 macro_rules! primitive_uniform_value {

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -14,7 +14,7 @@ pub trait OwnedUniforms {
 
 /// A trait for types which can represent themselves as `glium::UniformValue`.
 pub trait IntoUniformValue {
-    fn as_uniform_value(& self) -> UniformValue;
+    fn as_uniform_value(&self) -> UniformValue;
 }
 
 macro_rules! primitive_uniform_value {

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -37,7 +37,7 @@ macro_rules! referenced_uniform_value {
     };
 }
 
-primitive_uniform_value!(f32, |v| UniformValue::Float(v));
+primitive_uniform_value!(f32, UniformValue::Float);
 primitive_uniform_value!((f32, f32), |v: (f32, f32)| UniformValue::Vec2([v.0, v.1]));
 primitive_uniform_value!((f32, f32, f32), |v: (f32, f32, f32)| UniformValue::Vec3([
     v.0, v.1, v.2
@@ -45,14 +45,14 @@ primitive_uniform_value!((f32, f32, f32), |v: (f32, f32, f32)| UniformValue::Vec
 primitive_uniform_value!((f32, f32, f32, f32), |v: (f32, f32, f32, f32)| {
     UniformValue::Vec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([f32; 2], |v| UniformValue::Vec2(v));
-primitive_uniform_value!([f32; 3], |v| UniformValue::Vec3(v));
-primitive_uniform_value!([f32; 4], |v| UniformValue::Vec4(v));
-primitive_uniform_value!([[f32; 2]; 2], |v| UniformValue::Mat2(v));
-primitive_uniform_value!([[f32; 3]; 3], |v| UniformValue::Mat3(v));
-primitive_uniform_value!([[f32; 4]; 4], |v| UniformValue::Mat4(v));
+primitive_uniform_value!([f32; 2], UniformValue::Vec2);
+primitive_uniform_value!([f32; 3], UniformValue::Vec3);
+primitive_uniform_value!([f32; 4], UniformValue::Vec4);
+primitive_uniform_value!([[f32; 2]; 2], UniformValue::Mat2);
+primitive_uniform_value!([[f32; 3]; 3], UniformValue::Mat3);
+primitive_uniform_value!([[f32; 4]; 4], UniformValue::Mat4);
 
-primitive_uniform_value!(f64, |v| UniformValue::Double(v));
+primitive_uniform_value!(f64, UniformValue::Double);
 primitive_uniform_value!((f64, f64), |v: (f64, f64)| UniformValue::DoubleVec2([
     v.0, v.1
 ]));
@@ -62,14 +62,14 @@ primitive_uniform_value!((f64, f64, f64), |v: (f64, f64, f64)| {
 primitive_uniform_value!((f64, f64, f64, f64), |v: (f64, f64, f64, f64)| {
     UniformValue::DoubleVec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([f64; 2], |v| UniformValue::DoubleVec2(v));
-primitive_uniform_value!([f64; 3], |v| UniformValue::DoubleVec3(v));
-primitive_uniform_value!([f64; 4], |v| UniformValue::DoubleVec4(v));
-primitive_uniform_value!([[f64; 2]; 2], |v| UniformValue::DoubleMat2(v));
-primitive_uniform_value!([[f64; 3]; 3], |v| UniformValue::DoubleMat3(v));
-primitive_uniform_value!([[f64; 4]; 4], |v| UniformValue::DoubleMat4(v));
+primitive_uniform_value!([f64; 2], UniformValue::DoubleVec2);
+primitive_uniform_value!([f64; 3], UniformValue::DoubleVec3);
+primitive_uniform_value!([f64; 4], UniformValue::DoubleVec4);
+primitive_uniform_value!([[f64; 2]; 2], UniformValue::DoubleMat2);
+primitive_uniform_value!([[f64; 3]; 3], UniformValue::DoubleMat3);
+primitive_uniform_value!([[f64; 4]; 4], UniformValue::DoubleMat4);
 
-primitive_uniform_value!(i32, |v| UniformValue::SignedInt(v));
+primitive_uniform_value!(i32, UniformValue::SignedInt);
 primitive_uniform_value!((i32, i32), |v: (i32, i32)| UniformValue::IntVec2([
     v.0, v.1
 ]));
@@ -79,11 +79,11 @@ primitive_uniform_value!((i32, i32, i32), |v: (i32, i32, i32)| UniformValue::Int
 primitive_uniform_value!((i32, i32, i32, i32), |v: (i32, i32, i32, i32)| {
     UniformValue::IntVec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([i32; 2], |v| UniformValue::IntVec2(v));
-primitive_uniform_value!([i32; 3], |v| UniformValue::IntVec3(v));
-primitive_uniform_value!([i32; 4], |v| UniformValue::IntVec4(v));
+primitive_uniform_value!([i32; 2], UniformValue::IntVec2);
+primitive_uniform_value!([i32; 3], UniformValue::IntVec3);
+primitive_uniform_value!([i32; 4], UniformValue::IntVec4);
 
-primitive_uniform_value!(i64, |v| UniformValue::Int64(v));
+primitive_uniform_value!(i64, UniformValue::Int64);
 primitive_uniform_value!((i64, i64), |v: (i64, i64)| UniformValue::Int64Vec2([
     v.0, v.1
 ]));
@@ -93,11 +93,11 @@ primitive_uniform_value!((i64, i64, i64), |v: (i64, i64, i64)| {
 primitive_uniform_value!((i64, i64, i64, i64), |v: (i64, i64, i64, i64)| {
     UniformValue::Int64Vec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([i64; 2], |v| UniformValue::Int64Vec2(v));
-primitive_uniform_value!([i64; 3], |v| UniformValue::Int64Vec3(v));
-primitive_uniform_value!([i64; 4], |v| UniformValue::Int64Vec4(v));
+primitive_uniform_value!([i64; 2], UniformValue::Int64Vec2);
+primitive_uniform_value!([i64; 3], UniformValue::Int64Vec3);
+primitive_uniform_value!([i64; 4], UniformValue::Int64Vec4);
 
-primitive_uniform_value!(u64, |v| UniformValue::UnsignedInt64(v));
+primitive_uniform_value!(u64, UniformValue::UnsignedInt64);
 primitive_uniform_value!((u64, u64), |v: (u64, u64)| UniformValue::UnsignedInt64Vec2(
     [v.0, v.1]
 ));
@@ -107,11 +107,11 @@ primitive_uniform_value!((u64, u64, u64), |v: (u64, u64, u64)| {
 primitive_uniform_value!((u64, u64, u64, u64), |v: (u64, u64, u64, u64)| {
     UniformValue::UnsignedInt64Vec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([u64; 2], |v| UniformValue::UnsignedInt64Vec2(v));
-primitive_uniform_value!([u64; 3], |v| UniformValue::UnsignedInt64Vec3(v));
-primitive_uniform_value!([u64; 4], |v| UniformValue::UnsignedInt64Vec4(v));
+primitive_uniform_value!([u64; 2], UniformValue::UnsignedInt64Vec2);
+primitive_uniform_value!([u64; 3], UniformValue::UnsignedInt64Vec3);
+primitive_uniform_value!([u64; 4], UniformValue::UnsignedInt64Vec4);
 
-primitive_uniform_value!(u32, |v| UniformValue::UnsignedInt(v));
+primitive_uniform_value!(u32, UniformValue::UnsignedInt);
 primitive_uniform_value!((u32, u32), |v: (u32, u32)| UniformValue::UnsignedIntVec2([
     v.0, v.1
 ]));
@@ -121,11 +121,11 @@ primitive_uniform_value!((u32, u32, u32), |v: (u32, u32, u32)| {
 primitive_uniform_value!((u32, u32, u32, u32), |v: (u32, u32, u32, u32)| {
     UniformValue::UnsignedIntVec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([u32; 2], |v| UniformValue::UnsignedIntVec2(v));
-primitive_uniform_value!([u32; 3], |v| UniformValue::UnsignedIntVec3(v));
-primitive_uniform_value!([u32; 4], |v| UniformValue::UnsignedIntVec4(v));
+primitive_uniform_value!([u32; 2], UniformValue::UnsignedIntVec2);
+primitive_uniform_value!([u32; 3], UniformValue::UnsignedIntVec3);
+primitive_uniform_value!([u32; 4], UniformValue::UnsignedIntVec4);
 
-primitive_uniform_value!(bool, |v| UniformValue::Bool(v));
+primitive_uniform_value!(bool, UniformValue::Bool);
 primitive_uniform_value!((bool, bool), |v: (bool, bool)| UniformValue::BoolVec2([
     v.0, v.1
 ]));
@@ -135,9 +135,9 @@ primitive_uniform_value!((bool, bool, bool), |v: (bool, bool, bool)| {
 primitive_uniform_value!((bool, bool, bool, bool), |v: (bool, bool, bool, bool)| {
     UniformValue::BoolVec4([v.0, v.1, v.2, v.3])
 });
-primitive_uniform_value!([bool; 2], |v| UniformValue::BoolVec2(v));
-primitive_uniform_value!([bool; 3], |v| UniformValue::BoolVec3(v));
-primitive_uniform_value!([bool; 4], |v| UniformValue::BoolVec4(v));
+primitive_uniform_value!([bool; 2], UniformValue::BoolVec2);
+primitive_uniform_value!([bool; 3], UniformValue::BoolVec3);
+primitive_uniform_value!([bool; 4], UniformValue::BoolVec4);
 
 referenced_uniform_value!(Texture2d, |t| UniformValue::Texture2d(t, None));
 referenced_uniform_value!(

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -14,7 +14,7 @@ pub trait OwnedUniforms {
 
 /// A trait for types which can represent themselves as `glium::UniformValue`.
 pub trait IntoUniformValue {
-    fn into_uniform_value<'a>(&'a self) -> UniformValue<'a>;
+    fn as_uniform_value<'a>(&'a self) -> UniformValue<'a>;
 }
 
 macro_rules! primitive_uniform_value {

--- a/src/uniforms.rs
+++ b/src/uniforms.rs
@@ -20,7 +20,7 @@ pub trait IntoUniformValue {
 macro_rules! primitive_uniform_value {
     ($primitive:ty, $wrapper:expr) => {
         impl IntoUniformValue for $primitive {
-            fn into_uniform_value<'a>(&'a self) -> UniformValue<'a> {
+            fn as_uniform_value<'a>(&'a self) -> UniformValue<'a> {
                 $wrapper(*self)
             }
         }
@@ -30,7 +30,7 @@ macro_rules! primitive_uniform_value {
 macro_rules! referenced_uniform_value {
     ($base:ty, $wrapper:expr) => {
         impl IntoUniformValue for $base {
-            fn into_uniform_value<'a>(&'a self) -> UniformValue<'a> {
+            fn as_uniform_value<'a>(&'a self) -> UniformValue<'a> {
                 $wrapper(self)
             }
         }
@@ -165,7 +165,7 @@ mod test {
 
         let mut i = 0;
         OwnedUniforms::visit_owned_values(&uniforms, &mut |name: &str, value| {
-            let value = value.into_uniform_value();
+            let value = value.as_uniform_value();
             match i {
                 0 => match (name, value) {
                     ("camera", UniformValue::Vec3(pos)) if pos == [0., 0., 0.] => {}


### PR DESCRIPTION
Fixes the default lints when `cargo clippy` is ran on `turnage/valora:master`